### PR TITLE
Docs

### DIFF
--- a/cmd/pathctl/README.md
+++ b/cmd/pathctl/README.md
@@ -1,0 +1,25 @@
+# pathctl
+
+## Installation
+
+```shell
+go install al.essio.dev/pkg/tools/cmd/pathctl@latest
+```
+
+## Usage
+
+```shell
+pathctl [[append|prepend|drop] DIR]
+```
+
+**pathctl** streamlines operations over PATH-like environment variables.
+It provides idempotent operations add and remove directories from lists
+of directories typically separated by the  character ':' on POSIX
+systems (or the OS-specific path list separator). Also, it automatically
+removes duplicate elements as it encounters them.
+
+The append/prepend commands do nothing if the argument exists already
+in the path list; if invoked with the option -D, the already existing
+duplicate would be removed and the argument would be appended/prepended.
+
+See **pathctl -help** for more information.

--- a/cmd/portup/README.md
+++ b/cmd/portup/README.md
@@ -1,0 +1,17 @@
+# portup
+
+## Installation
+
+```shell
+go install al.essio.dev/pkg/tools/cmd/portup@latest
+```
+
+## Usage
+
+```shell
+portup [-with-reclaim]
+```
+
+**portup** is a convenience shortcut to update and
+[MacPorts](https://www.macports.org)'s ports tree and upgrade installed
+packages.

--- a/cmd/portup/main.go
+++ b/cmd/portup/main.go
@@ -91,9 +91,9 @@ func openLogFile(filename string) (io.WriteCloser, error) {
 
 func usage() {
 	_, _ = fmt.Fprintf(os.Stderr, `Usage: %s [PATH]
-This command is a simple and convenient shorcut
-to update and upgrade the packages installed
-with MacPorts.
+This command is a simple and convenient shortcut
+to update the ports tree and upgrade the packages
+installed with MacPorts.
 
 Options:
 `, programName)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `pathctl`, a command-line tool for managing PATH-like environment variables.
	- Launched `portup`, a command-line utility for updating the MacPorts ports tree and installed packages.

- **Documentation**
	- Updated the help text in `portup` to clarify its functionality for updating the ports tree and upgrading packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->