### PR TITLE
Potential fix for code scanning alert no. 28: Uncontrolled data used in path expression

### DIFF
--- a/cmd/popbak/main.go
+++ b/cmd/popbak/main.go
@@ -44,12 +44,17 @@ func restoreDirectory(target string, backups *dirsnapshots.Backups) error {
 		return fmt.Errorf("no backups available")
 	}
 
+	origPath, err := backups.ResolveSnapshotPath(orig)
+	if err != nil {
+		return fmt.Errorf("invalid snapshot path %q: %v", orig, err)
+	}
+
 	if err := os.RemoveAll(target); err != nil {
 		return fmt.Errorf("couldn't remove %q: %v", target, err)
 	}
 
-	if err := os.Rename(orig, target); err != nil {
-		return fmt.Errorf("couldn't rename %q: %v", orig, err)
+	if err := os.Rename(origPath, target); err != nil {
+		return fmt.Errorf("couldn't rename %q: %v", origPath, err)
 	}
 
 	return nil

--- a/internal/dirsnapshots/config.go
+++ b/internal/dirsnapshots/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -93,6 +94,32 @@ func (b *Backups) PopDir(orig string) (string, bool) {
 
 // SnapshotsDir returns the snapshots base path.
 func (b *Backups) SnapshotsDir() string { return b.snapshotsDir }
+
+// ResolveSnapshotPath resolves a stored snapshot path against the snapshotsDir
+// and ensures that the resulting path stays within snapshotsDir.
+func (b *Backups) ResolveSnapshotPath(rel string) (string, error) {
+	base := filepath.Clean(b.snapshotsDir)
+	baseAbs, err := filepath.Abs(base)
+	if err != nil {
+		return "", fmt.Errorf("couldn't resolve snapshots base directory: %w", err)
+	}
+
+	joined := filepath.Join(baseAbs, rel)
+	resolved, err := filepath.Abs(joined)
+	if err != nil {
+		return "", fmt.Errorf("couldn't resolve snapshot path: %w", err)
+	}
+
+	baseWithSep := baseAbs
+	if !strings.HasSuffix(baseWithSep, string(os.PathSeparator)) {
+		baseWithSep += string(os.PathSeparator)
+	}
+	if resolved != baseAbs && !strings.HasPrefix(resolved, baseWithSep) {
+		return "", fmt.Errorf("snapshot path %q escapes snapshots directory %q", resolved, baseAbs)
+	}
+
+	return resolved, nil
+}
 
 // ensureConfigDir ensures that the user's Backups directory
 // is created and returns its absolute path.


### PR DESCRIPTION
Potential fix for [https://github.com/alessio/unixtools/security/code-scanning/28](https://github.com/alessio/unixtools/security/code-scanning/28)

In general, to fix uncontrolled path usage here, we should ensure that any path read from configuration (the backup path `orig`) is constrained to the tool’s snapshots directory before using it in `os.Rename`. That means: compute the absolute path to the snapshots directory, resolve `orig` against it, and verify that the resulting path is within that directory (no `..` escapes, no absolute paths elsewhere); only then call `os.Rename`.

The best fix with minimal behavior change is:

- Add a method on `*Backups` to resolve a stored snapshot path safely under `b.snapshotsDir`. This method can:
  - Join `b.snapshotsDir` and the stored value.
  - Convert the result to an absolute path.
  - Convert `b.snapshotsDir` to an absolute path.
  - Check that the resolved absolute path has the snapshots directory as its clean prefix (e.g., using `filepath.Clean` and `strings.HasPrefix` with an appended path separator).
  - Return an error if validation fails.
- In `restoreDirectory`, after `PopDir`, pass the returned `orig` through this resolver and use the safe resolved path in `os.Rename` instead of the raw `orig` value.
- Keep the `target` path logic unchanged, since it already comes from a CLI argument and is canonicalized with `filepath.Abs`.

Concretely:

- In `internal/dirsnapshots/config.go`, add a method:

  ```go
  func (b *Backups) ResolveSnapshotPath(rel string) (string, error) { ... }
  ```

  that uses `filepath.Abs`, `filepath.Clean`, and `strings.HasPrefix` to ensure the final path is inside `b.snapshotsDir`.

- In `cmd/popbak/main.go`, update `restoreDirectory` to:

  - Call `backups.ResolveSnapshotPath(orig)` and store the result in, say, `origPath`.
  - Use `origPath` in `os.Rename(origPath, target)` and in error messages instead of the unvalidated `orig`.

We need to import `strings` in `internal/dirsnapshots/config.go` to implement the prefix check. No other external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
