### PR TITLE
Clean file path for stamp file return

### DIFF
--- a/cmd/elvoke/main.go
+++ b/cmd/elvoke/main.go
@@ -232,7 +232,7 @@ func stampFilename(ident string) string {
 		return stampfile
 	}
 
-	return filepath.Join(cachedir, fmt.Sprintf("%s.stamp", ident))
+	return filepath.Clean(filepath.Join(cachedir, fmt.Sprintf("%s.stamp", ident)))
 }
 
 func cmdIdent(cmd *exec.Cmd) string {


### PR DESCRIPTION
Ensure the file path is cleaned before returning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file path normalization to ensure consistent and reliable cache file operations, removing redundant path elements for improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->