### PR TITLE
Potential fix for code scanning alert no. 35: Uncontrolled data used in path expression

### DIFF
--- a/cmd/elvoke/main.go
+++ b/cmd/elvoke/main.go
@@ -8,7 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
+"os/exec"
+"path/filepath"
 	"strings"
 	"time"
 

--- a/cmd/elvoke/main.go
+++ b/cmd/elvoke/main.go
@@ -152,7 +152,7 @@ func ensureCache() {
 		log.Fatal(err)
 	}
 
-	cachedir, err = normalizeDir(path.Join(homedir, ".elvoke"))
+	cachedir, err = normalizeDir(filepath.Join(homedir, ".elvoke"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -181,16 +181,16 @@ func mustMkDirAll(s string) {
 		log.Fatal("directory path is empty")
 	}
 
-	absPath, err := filepath.Abs(s)
+	normalized, err := normalizeDir(s)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if !filepath.IsAbs(absPath) {
+	if !filepath.IsAbs(normalized) {
 		log.Fatal("directory path is not absolute")
 	}
 
-	if err := os.MkdirAll(absPath, os.ModePerm); err != nil {
+	if err := os.MkdirAll(normalized, os.ModePerm); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -203,6 +203,11 @@ func normalizeDir(dir string) (string, error) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
 		return "", err
+	}
+
+	// Basic sanity check: reject paths with parent directory traversals.
+	if strings.Contains(absDir, "..") {
+		return "", fmt.Errorf("directory path contains invalid components")
 	}
 
 	return absDir, nil

--- a/cmd/elvoke/main.go
+++ b/cmd/elvoke/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"os/exec"
 	"path/filepath"
 	"strings"

--- a/cmd/elvoke/main.go
+++ b/cmd/elvoke/main.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"os/exec"
-"path/filepath"
+	"path/filepath"
 	"strings"
 	"time"
 

--- a/cmd/elvoke/main.go
+++ b/cmd/elvoke/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"

--- a/cmd/elvoke/main.go
+++ b/cmd/elvoke/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
-"os/exec"
+	"os/exec"
 "path/filepath"
 	"strings"
 	"time"


### PR DESCRIPTION
Potential fix for [https://github.com/alessio/unixtools/security/code-scanning/35](https://github.com/alessio/unixtools/security/code-scanning/35)

General approach: Ensure that any directory path derived from “user-provided” data is normalized, sanity-checked, and constrained as appropriate before being passed into `os.MkdirAll`. In this code, that primarily affects `mustMkDirAll` and the way `cachedir` is derived and validated.

Best concrete fix here, without changing intended behavior:

1. Strengthen `normalizeDir` so that it not only computes an absolute path but also rejects obviously unsafe inputs (for example, paths containing `..` components), similar to what `validateEnvDir` already does.
2. Reuse `normalizeDir` inside `mustMkDirAll` so that every directory it creates is subject to the same normalization and basic validation, regardless of where the input came from (`ELVOKE_HOME`, `$HOME/.elvoke`, `$XDG_CACHE_HOME/elvoke`, or any future use).
3. Replace the use of `path.Join` with `filepath.Join` when constructing the `$HOME/.elvoke` directory so that path manipulation uses the OS-specific path semantics consistently.

Concretely, in `cmd/elvoke/main.go`:

- Update `normalizeDir` to:
  - Return an error if, after `filepath.Abs`, the resulting path string contains `..` (rudimentary traversal indicator), similar to `validateEnvDir`.
  - Keep the existing behavior of returning the absolute path.
- Update `mustMkDirAll` to:
  - Call `normalizeDir` instead of re‑implementing absolute-path logic.
  - Optionally perform a final `filepath.IsAbs` check on the normalized result (defensive but should already hold).
- Change line 155 to use `filepath.Join` instead of `path.Join`. Since `filepath` is already imported, this introduces no new dependencies and keeps behavior correct across platforms.

No new methods or imports are needed; we just refactor and tighten existing helpers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
