### PR TITLE
Potential fix for code scanning alert no. 34: Uncontrolled data used in path expression

### DIFF
--- a/internal/dirsnapshots/config.go
+++ b/internal/dirsnapshots/config.go
@@ -124,12 +124,13 @@ func (b *Backups) ResolveSnapshotPath(rel string) (string, error) {
 // ensureConfigDir ensures that the user's Backups directory
 // is created and returns its absolute path.
 func ensureConfigDir() string {
-	configDir, err := os.UserConfigDir()
+	userConfigDir, err := os.UserConfigDir()
 	if err != nil {
 		panic(err)
 	}
 
-	snapshotsDir := filepath.Join(configDir, configDirname, snapshotsDirName)
+	configDir := filepath.Join(userConfigDir, configDirname)
+	snapshotsDir := filepath.Join(configDir, snapshotsDirName)
 	if err := os.MkdirAll(snapshotsDir, 0755); err != nil {
 		panic(fmt.Errorf("couldn't create %q: %w", snapshotsDir, err))
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/alessio/unixtools/security/code-scanning/34](https://github.com/alessio/unixtools/security/code-scanning/34)

Use a canonical, fixed snapshots base directory and validate paths against that canonical base before rename.

Best single fix with minimal behavior change:
1. In `internal/dirsnapshots/config.go`, make `ensureConfigDir()` return the concrete app config base directory (`<UserConfigDir>/dirsnapshots`) instead of raw `UserConfigDir()`.
2. Keep `Load()`/`Save()` joining filenames from that base (already done), so config and snapshots stay in one controlled tree.
3. `ResolveSnapshotPath` already performs containment checks; with the corrected base directory, `origPath` is constrained to `<UserConfigDir>/dirsnapshots/snapshots/...`, addressing both alert variants consistently.

This only requires edits in `internal/dirsnapshots/config.go`; no new methods or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
