### PR TITLE
Potential fix for code scanning alert no. 36: Uncontrolled data used in path expression

### DIFF
--- a/cmd/pushbak/main.go
+++ b/cmd/pushbak/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"path/filepath"
 
 	"al.essio.dev/pkg/tools/internal/dirsnapshots"
 	"al.essio.dev/pkg/tools/internal/file"

--- a/cmd/pushbak/main.go
+++ b/cmd/pushbak/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"log"
 	"os"
-	"path/filepath"
 
 	"al.essio.dev/pkg/tools/internal/dirsnapshots"
 	"al.essio.dev/pkg/tools/internal/file"
@@ -45,8 +44,7 @@ func main() {
 }
 
 func backupDirectory(target string, backups *dirsnapshots.Backups) error {
-	snapshotsBase := filepath.Clean(backups.SnapshotsDir())
-	snapshotsBaseAbs, err := filepath.Abs(snapshotsBase)
+	snapshotsBaseAbs, err := backups.ResolveSnapshotPath(".")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/alessio/unixtools/security/code-scanning/36](https://github.com/alessio/unixtools/security/code-scanning/36)

General fix: validate and constrain filesystem paths derived from external/config/environment sources before using them in path-sensitive operations. For directory creation, resolve to absolute paths and ensure the effective path remains within an expected safe base.

Best fix here (without changing behavior): in `cmd/pushbak/main.go` inside `backupDirectory`, stop using `backups.SnapshotsDir()` directly for `MkdirTemp`; instead, resolve it through the existing safe helper `backups.ResolveSnapshotPath(".")`, which normalizes and enforces containment in the configured snapshots directory. Then pass the resolved path to `os.MkdirTemp`.

Edits needed:
- **File:** `cmd/pushbak/main.go`
- **Region:** `backupDirectory` function, lines around current `snapshotsBase := filepath.Clean(backups.SnapshotsDir())` and `filepath.Abs(...)`.
- **Change:** replace manual clean/abs logic with `snapshotsBaseAbs, err := backups.ResolveSnapshotPath(".")`.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal path resolution logic for backup directory handling, optimizing how snapshot base paths are computed and resolved during backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->