### PR TITLE
Potential fix for code scanning alert no. 36: Uncontrolled data used in path expression

### DIFF
--- a/cmd/pushbak/main.go
+++ b/cmd/pushbak/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"al.essio.dev/pkg/tools/internal/dirsnapshots"
 	"al.essio.dev/pkg/tools/internal/file"
@@ -72,11 +71,11 @@ func validateSnapshotBaseDir(baseDir, expectedRoot string) (string, error) {
 		return "", os.ErrInvalid
 	}
 
-	rootWithSep := rootEval
-	if !strings.HasSuffix(rootWithSep, string(os.PathSeparator)) {
-		rootWithSep += string(os.PathSeparator)
+	rel, err := filepath.Rel(rootEval, baseEval)
+	if err != nil {
+		return "", err
 	}
-	if baseEval != rootEval && !strings.HasPrefix(baseEval, rootWithSep) {
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
 		return "", os.ErrPermission
 	}
 

--- a/cmd/pushbak/main.go
+++ b/cmd/pushbak/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"al.essio.dev/pkg/tools/internal/dirsnapshots"
 	"al.essio.dev/pkg/tools/internal/file"
@@ -44,8 +45,51 @@ func main() {
 	}
 }
 
+func validateSnapshotBaseDir(baseDir, expectedRoot string) (string, error) {
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", err
+	}
+	baseEval, err := filepath.EvalSymlinks(baseAbs)
+	if err != nil {
+		return "", err
+	}
+
+	rootAbs, err := filepath.Abs(expectedRoot)
+	if err != nil {
+		return "", err
+	}
+	rootEval, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return "", err
+	}
+
+	info, err := os.Stat(baseEval)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", os.ErrInvalid
+	}
+
+	rootWithSep := rootEval
+	if !strings.HasSuffix(rootWithSep, string(os.PathSeparator)) {
+		rootWithSep += string(os.PathSeparator)
+	}
+	if baseEval != rootEval && !strings.HasPrefix(baseEval, rootWithSep) {
+		return "", os.ErrPermission
+	}
+
+	return baseEval, nil
+}
+
 func backupDirectory(target string, backups *dirsnapshots.Backups) error {
 	snapshotsBaseAbs, err := backups.ResolveSnapshotPath(".")
+	if err != nil {
+		return err
+	}
+
+	snapshotsBaseAbs, err = validateSnapshotBaseDir(snapshotsBaseAbs, backups.SnapshotsDir())
 	if err != nil {
 		return err
 	}

--- a/internal/dirsnapshots/config.go
+++ b/internal/dirsnapshots/config.go
@@ -110,11 +110,11 @@ func (b *Backups) ResolveSnapshotPath(rel string) (string, error) {
 		return "", fmt.Errorf("couldn't resolve snapshot path: %w", err)
 	}
 
-	baseWithSep := baseAbs
-	if !strings.HasSuffix(baseWithSep, string(os.PathSeparator)) {
-		baseWithSep += string(os.PathSeparator)
+	relToBase, err := filepath.Rel(baseAbs, resolved)
+	if err != nil {
+		return "", fmt.Errorf("couldn't evaluate snapshot path containment: %w", err)
 	}
-	if resolved != baseAbs && !strings.HasPrefix(resolved, baseWithSep) {
+	if relToBase == ".." || strings.HasPrefix(relToBase, ".."+string(os.PathSeparator)) || filepath.IsAbs(relToBase) {
 		return "", fmt.Errorf("snapshot path %q escapes snapshots directory %q", resolved, baseAbs)
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/alessio/unixtools/security/code-scanning/36](https://github.com/alessio/unixtools/security/code-scanning/36)

General fix: before using any path derived from config/environment in filesystem-creation APIs, canonicalize it and enforce that it is an existing directory under the expected safe base directory.

Best targeted fix here: in `cmd/pushbak/main.go`, after `ResolveSnapshotPath(".")`, resolve both:
- `snapshotsBaseAbs` (the candidate temp base), and
- `backups.SnapshotsDir()` (the expected configured snapshots root),

via `filepath.Abs` + `filepath.EvalSymlinks`, then verify:
1. candidate is a directory (`os.Stat`),
2. candidate equals expected root or is a child of it (prefix check with path separator).

This keeps existing behavior (still uses configured snapshots dir) while preventing redirection via unexpected path manipulation/symlink tricks. Only `cmd/pushbak/main.go` needs edits; no new external deps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Strengthened validation of backup directory paths to prevent escape attempts and access outside the intended root directory, blocking absolute paths, upward traversal attempts, and non-existent directories.
* Improved snapshot path containment verification using enhanced path resolution and validation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->