### PR TITLE
Potential fix for code scanning alert no. 36: Uncontrolled data used in path expression

### DIFF
--- a/cmd/pushbak/main.go
+++ b/cmd/pushbak/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"al.essio.dev/pkg/tools/internal/dirsnapshots"
 	"al.essio.dev/pkg/tools/internal/file"
@@ -44,8 +45,51 @@ func main() {
 	}
 }
 
+func validateSnapshotBaseDir(baseDir, expectedRoot string) (string, error) {
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", err
+	}
+	baseEval, err := filepath.EvalSymlinks(baseAbs)
+	if err != nil {
+		return "", err
+	}
+
+	rootAbs, err := filepath.Abs(expectedRoot)
+	if err != nil {
+		return "", err
+	}
+	rootEval, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return "", err
+	}
+
+	info, err := os.Stat(baseEval)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", os.ErrInvalid
+	}
+
+	rootWithSep := rootEval
+	if !strings.HasSuffix(rootWithSep, string(os.PathSeparator)) {
+		rootWithSep += string(os.PathSeparator)
+	}
+	if baseEval != rootEval && !strings.HasPrefix(baseEval, rootWithSep) {
+		return "", os.ErrPermission
+	}
+
+	return baseEval, nil
+}
+
 func backupDirectory(target string, backups *dirsnapshots.Backups) error {
 	snapshotsBaseAbs, err := backups.ResolveSnapshotPath(".")
+	if err != nil {
+		return err
+	}
+
+	snapshotsBaseAbs, err = validateSnapshotBaseDir(snapshotsBaseAbs, backups.SnapshotsDir())
 	if err != nil {
 		return err
 	}

--- a/cmd/pushbak/main.go
+++ b/cmd/pushbak/main.go
@@ -72,11 +72,11 @@ func validateSnapshotBaseDir(baseDir, expectedRoot string) (string, error) {
 		return "", os.ErrInvalid
 	}
 
-	rootWithSep := rootEval
-	if !strings.HasSuffix(rootWithSep, string(os.PathSeparator)) {
-		rootWithSep += string(os.PathSeparator)
+	rel, err := filepath.Rel(rootEval, baseEval)
+	if err != nil {
+		return "", err
 	}
-	if baseEval != rootEval && !strings.HasPrefix(baseEval, rootWithSep) {
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
 		return "", os.ErrPermission
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/alessio/unixtools/security/code-scanning/36](https://github.com/alessio/unixtools/security/code-scanning/36)

General fix: before using any path derived from config/environment in filesystem-creation APIs, canonicalize it and enforce that it is an existing directory under the expected safe base directory.

Best targeted fix here: in `cmd/pushbak/main.go`, after `ResolveSnapshotPath(".")`, resolve both:
- `snapshotsBaseAbs` (the candidate temp base), and
- `backups.SnapshotsDir()` (the expected configured snapshots root),

via `filepath.Abs` + `filepath.EvalSymlinks`, then verify:
1. candidate is a directory (`os.Stat`),
2. candidate equals expected root or is a child of it (prefix check with path separator).

This keeps existing behavior (still uses configured snapshots dir) while preventing redirection via unexpected path manipulation/symlink tricks. Only `cmd/pushbak/main.go` needs edits; no new external deps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
